### PR TITLE
fix: specify target os

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,12 +37,14 @@ serde_json = "1.0.135"
 # Consider to migrate to xcap
 screenshots = "0.8.10"
 xcap = "0.2.1"
-cocoa = "0.26.0"
 base64 = "0.22.1"
 fs_extra = "1.3.0"
 directories = "5.0.1"
 chrono = "0.4.39"
 active-win-pos-rs = "0.9"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+cocoa = "0.26.0"
 
 # Maybe unused
 # scrap = "0.5.0"

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -1,7 +1,8 @@
 use tauri::{
-    AppHandle, Emitter, Manager, PhysicalPosition, TitleBarStyle, WebviewUrl, WebviewWindow,
-    WebviewWindowBuilder,
+    AppHandle, Emitter, Manager, PhysicalPosition, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
 };
+#[cfg(target_os = "macos")]
+use tauri::TitleBarStyle;
 
 use crate::constant::ON_REOPEN_APP_EVENT;
 


### PR DESCRIPTION
## Description

i run `bun run tdev` but get this error

```bash
error[E0455]: link kind `framework` is only supported on Apple targets
   --> /home/oxwazz/.cargo/registry/src/index.crates.io-6f17d22bba15001f/core-graphics-types-0.2.0/src/geometry.rs:169:69
    |
169 |     #[cfg_attr(feature = "link", link(name = "CoreGraphics", kind = "framework"))]
    |                                                                     ^^^^^^^^^^^

For more information about this error, try `rustc --explain E0455`.
error: could not compile `core-graphics-types` (lib) due to 1 previous error

```

This PR addresses a compatibility issue where certain code or dependencies were not explicitly configured for macOS only. By adding the required adjustments, the issue has been resolved, and the application now works seamlessly on Ubuntu.


## Addition

**Platform**         : linux
**Distro**           : Ubuntu
**Release**          : 24.04.1 LTS
**Codename**         : noble
**Kernel**           : 6.8.0-51-generic
**Arch**             : x64